### PR TITLE
fix 1dnn MatMul+ScaleShift for inference

### DIFF
--- a/intel_extension_for_deepspeed/op_builder/csrc/transformer/inference/csrc/inference_onednn_wrappers.cpp
+++ b/intel_extension_for_deepspeed/op_builder/csrc/transformer/inference/csrc/inference_onednn_wrappers.cpp
@@ -107,19 +107,12 @@ inline int onednn_matmul(sycl::queue handle,
     auto dst_mem = dnnl::memory(dst_md, engine, (void*)dst_ptr);
 
     dnnl::primitive_attr attr;
+    if (alpha != 1.0f || beta != 0.0f) {
+      dnnl::post_ops po;
+      po.append_eltwise(dnnl::algorithm::eltwise_linear, alpha, beta);
+      attr.set_post_ops(po);
+    }
     attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    std::unordered_map<int, dnnl::memory> matmul_args;
-    if (alpha != 1.0f) {
-        float alpha_v(alpha);
-        attr.set_scales_mask(DNNL_ARG_DST, /* mask */ 0);
-        dnnl::memory alpha_mem({{1}, dnnl::memory::data_type::f32, {1}}, engine, &alpha_v);
-        matmul_args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, alpha_mem});
-    }
-    if (beta != 0.0f) {
-        dnnl::post_ops po;
-        po.append_sum(beta);
-        attr.set_post_ops(po);
-    }
 
     auto matmul_pd = dnnl::matmul::primitive_desc(engine, src_md, wgt_md, dst_md, attr);
 
@@ -133,6 +126,7 @@ inline int onednn_matmul(sycl::queue handle,
     auto scratchpad_tensor = at::empty({(int64_t)scratchpad_md.get_size()}, options);
     dnnl::memory scratchpad(scratchpad_md, engine, scratchpad_tensor.data_ptr());
 
+    std::unordered_map<int, dnnl::memory> matmul_args;
     matmul_args.insert({DNNL_ARG_SRC, src_mem});
     matmul_args.insert({DNNL_ARG_WEIGHTS, wgt_mem});
     matmul_args.insert({DNNL_ARG_DST, dst_mem});


### PR DESCRIPTION
old implementation is for CPU path, failed on GPU path to scale output.
Ref: https://oneapi-src.github.io/oneDNN/dev_guide_attributes_post_ops.html#tanh-sum-scaleshift